### PR TITLE
Remove allowedSignHash from sign PSBT args + some fixes

### DIFF
--- a/.github/workflows/build-and-publish-pr.yml
+++ b/.github/workflows/build-and-publish-pr.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run test build
+        run: npm run build-debug
+
       - name: Run build
         run: npm run build
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,10 @@
         "bitcoin-address-validation": "2.2.3",
         "buffer": "6.0.3",
         "jsontokens": "4.0.1",
-        "lodash.omit": "4.5.0",
         "valibot": "0.33.2"
       },
       "devDependencies": {
         "@types/jest": "^29.2.6",
-        "@types/lodash.omit": "4.5.9",
         "husky": "^8.0.3",
         "lint-staged": "^13.2.3",
         "prettier": "3.3.3",
@@ -1927,21 +1925,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
-      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
-      "dev": true
-    },
-    "node_modules/@types/lodash.omit": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.omit/-/lodash.omit-4.5.9.tgz",
-      "integrity": "sha512-zuAVFLUPJMOzsw6yawshsYGgq2hWUHtsZgeXHZmSFhaQQFC6EQ021uDKHkSjOpNhSvtNSU9165/o3o/Q51GpTw==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "18.14.2",
@@ -5034,11 +5017,6 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true
-    },
-    "node_modules/lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg=="
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
@@ -8548,21 +8526,6 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
-      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
-      "dev": true
-    },
-    "@types/lodash.omit": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.omit/-/lodash.omit-4.5.9.tgz",
-      "integrity": "sha512-zuAVFLUPJMOzsw6yawshsYGgq2hWUHtsZgeXHZmSFhaQQFC6EQ021uDKHkSjOpNhSvtNSU9165/o3o/Q51GpTw==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/node": {
       "version": "18.14.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.2.tgz",
@@ -10831,11 +10794,6 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true
-    },
-    "lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "build-debug": "webpack --mode development",
+    "build-debug": "npm run clean && webpack --mode development",
     "build": "npm run clean && tsup src/index.ts --format esm --dts",
     "build:watch": "npm run clean && tsup src/index.ts --format esm --dts --watch",
     "clean": "rimraf dist",
@@ -29,12 +29,10 @@
     "bitcoin-address-validation": "2.2.3",
     "buffer": "6.0.3",
     "jsontokens": "4.0.1",
-    "lodash.omit": "4.5.0",
     "valibot": "0.33.2"
   },
   "devDependencies": {
     "@types/jest": "^29.2.6",
-    "@types/lodash.omit": "4.5.9",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.3",
     "prettier": "3.3.3",

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -1,6 +1,5 @@
 import { DefaultAdaptersInfo } from '../adapters';
-import { type SupportedWallet, type BitcoinProvider, type Provider } from './types';
-import omit from 'lodash.omit';
+import { type BitcoinProvider, type Provider, type SupportedWallet } from './types';
 
 export async function getProviderOrThrow(
   getProvider?: () => Promise<BitcoinProvider | undefined>
@@ -41,11 +40,11 @@ export function removeDefaultProvider() {
 }
 
 export function getSupportedWallets(): SupportedWallet[] {
-  const btc_providers = getProviders();
-  const allProviders = [...btc_providers];
-  for (const key in omit(DefaultAdaptersInfo, ['xverse'])) {
-    allProviders.push(DefaultAdaptersInfo[key]);
-  }
+  const ambientProviders = getProviders();
+  const { xverse, ...defaultProviders } = DefaultAdaptersInfo;
+
+  const allProviders = [...ambientProviders, ...Object.values(defaultProviders)];
+
   const wallets: SupportedWallet[] = allProviders.map((provider) => {
     {
       return {

--- a/src/request/types/btcMethods.ts
+++ b/src/request/types/btcMethods.ts
@@ -2,9 +2,9 @@
  * Represents the types and interfaces related to BTC methods.
  */
 
+import * as v from 'valibot';
 import { AddressPurpose, addressSchema } from '../../addresses';
 import { MethodParamsAndResult, rpcRequestMessageSchema } from '../../types';
-import * as v from 'valibot';
 import { walletTypeSchema } from './common';
 
 export const getInfoMethodName = 'getInfo';
@@ -167,11 +167,6 @@ export type SignPsbtParams = {
    * The key is the address and the value is an array of indexes of the inputs to sign.
    */
   signInputs: Record<string, number[]>;
-  /**
-   * the sigHash type to use for signing.
-   * will default to the sighash type of the input if not provided.
-   **/
-  allowedSignHash?: number;
   /**
    * Whether to broadcast the transaction after signing.
    **/

--- a/src/request/types/stxMethods.ts
+++ b/src/request/types/stxMethods.ts
@@ -1,6 +1,6 @@
-import { addressSchema } from 'src/addresses';
-import { MethodParamsAndResult, rpcRequestMessageSchema } from '../../types';
 import * as v from 'valibot';
+import { addressSchema } from '../../addresses';
+import { MethodParamsAndResult, rpcRequestMessageSchema } from '../../types';
 
 interface Pubkey {
   /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,12 +15,6 @@ module.exports = {
     libraryTarget: 'var',
     path: path.resolve(process.cwd(), 'dist'),
   },
-  plugins: [
-    new webpack.ProvidePlugin({
-      process: 'process/browser',
-      fetch: 'cross-fetch',
-    }),
-  ],
   optimization: {
     minimize: isProduction,
   },


### PR DESCRIPTION
- allowedSignHash was removed as the implementation no longer requires it. It is also optional for Unisat, so there isn't a breaking change for the unisat integration.
- lodash.omit was removed to decrease dependencies and was replaced with a basic, vanilla JS spread operator
- a relative import was fixed
- The Unisat adapter was brought up to date with the event listener function
- The GitHub workflow was changed to run the build-debug script as the build script seems to ignore typing issues (like the missing Unisat method in pervious point)