### PR TITLE
fix: Unisat integration signPsbt functionality [ENG-5091]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sats-connect/core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sats-connect/core",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "ISC",
       "dependencies": {
         "axios": "1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sats-connect/core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.mts",

--- a/src/adapters/unisat.ts
+++ b/src/adapters/unisat.ts
@@ -135,15 +135,16 @@ class UnisatAdapter extends SatsConnectAdapter {
       autoFinalized: broadcast,
       toSignInputs: convertSignInputsToInputType(signInputs),
     });
+    const signedPsbtBase64 = Buffer.from(signedPsbt, 'hex').toString('base64');
+
+    let txid: string | undefined;
     if (broadcast) {
-      const txid = await window.unisat.pushPsbt(psbtHex);
-      return {
-        psbt: signedPsbt,
-        txid,
-      };
+      txid = await window.unisat.pushPsbt(signedPsbt);
     }
+
     return {
-      psbt: psbtHex,
+      psbt: signedPsbtBase64,
+      txid,
     };
   }
 


### PR DESCRIPTION
Fixes a few issues with the unisat provider's signPsbt method:
- the method now returns a base64 version of the signed PSBT
- broadcasting now works