### PR TITLE
Add testnet4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sats-connect/core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sats-connect/core",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "ISC",
       "dependencies": {
         "axios": "1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sats-connect/core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.mts",

--- a/src/runes/api.ts
+++ b/src/runes/api.ts
@@ -19,8 +19,8 @@ const urlNetworkSuffix = {
   [BitcoinNetworkType.Signet]: '-signet',
 };
 export const ORDINALS_API_BASE_URL = (network: BitcoinNetworkType = BitcoinNetworkType.Mainnet) => {
-  if (network === BitcoinNetworkType.Regtest) {
-    throw new Error('Ordinals API does not support regtest network');
+  if (network === BitcoinNetworkType.Regtest || network === BitcoinNetworkType.Testnet4) {
+    throw new Error(`Ordinals API does not support ${network} network`);
   }
   return `https://ordinals${urlNetworkSuffix[network]}.xverse.app/v1`;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import { Requests, Return } from './request';
 export enum BitcoinNetworkType {
   Mainnet = 'Mainnet',
   Testnet = 'Testnet',
+  Testnet4 = 'Testnet4',
   Signet = 'Signet',
   Regtest = 'Regtest',
 }


### PR DESCRIPTION
Add testnet4 as supported network. Mark runes mint&etch apis as unsuported for testnet4.