### PR TITLE
fix: add fordefi to default adapters record

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sats-connect/core",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.mts",

--- a/src/adapters/fordefi.ts
+++ b/src/adapters/fordefi.ts
@@ -36,24 +36,7 @@ class FordefiAdapter extends SatsConnectAdapter {
       throw new Error('A wallet method is required');
     }
 
-    try {
-      const response = await provider.request(method, params);
-
-      return {
-        status: 'success',
-        result: response as Return<Method>,
-      };
-    } catch (error) {
-      console.error('Error calling the method', error);
-      return {
-        status: 'error',
-        error: {
-          code: error.code === 4001 ? RpcErrorCode.USER_REJECTION : RpcErrorCode.INTERNAL_ERROR,
-          message: error.message ? error.message : 'Wallet method call error',
-          data: error,
-        },
-      };
-    }
+    return await provider.request(method, params);
   };
 
   public addListener: AddListener = (eventName, cb) => {

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -2,6 +2,7 @@ import { XverseAdapter } from './xverse';
 import { SatsConnectAdapter } from './satsConnectAdapter';
 import { UnisatAdapter } from './unisat';
 import { Provider } from '../provider';
+import { FordefiAdapter } from './fordefi';
 
 export const DefaultAdaptersInfo: Record<string, Provider> = {
   fordefi: {
@@ -31,6 +32,7 @@ export const DefaultAdaptersInfo: Record<string, Provider> = {
 };
 
 export const defaultAdapters: Record<string, new () => SatsConnectAdapter> = {
+  [DefaultAdaptersInfo.fordefi.id]: FordefiAdapter,
   [DefaultAdaptersInfo.xverse.id]: XverseAdapter,
   [DefaultAdaptersInfo.unisat.id]: UnisatAdapter,
 };


### PR DESCRIPTION
I noticed I forgot to update the `defaultAdapters` record with fordefi 🤦 
also removed the extra rpc wrapping.. we already return request with the rpc wrapping