### PR TITLE
Feat: Support optional puplicKey for stx_sign message request [ENG-6735]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.1",
       "license": "ISC",
       "dependencies": {
-        "axios": "1.7.7",
+        "axios": "1.8.4",
         "bitcoin-address-validation": "2.2.3",
         "buffer": "6.0.3",
         "jsontokens": "4.0.1",
@@ -2150,9 +2150,10 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "dependencies": {
-    "axios": "1.7.7",
+    "axios": "1.8.4",
     "bitcoin-address-validation": "2.2.3",
     "buffer": "6.0.3",
     "jsontokens": "4.0.1",

--- a/src/request/types/stxMethods/signMessage.ts
+++ b/src/request/types/stxMethods/signMessage.ts
@@ -8,16 +8,6 @@ export const stxSignMessageParamsSchema = v.object({
    * The message to sign.
    */
   message: v.string(),
-
-  /**
-   * The public key to sign the message with.
-   */
-  publicKey: v.optional(v.string()),
-
-  /**
-   * The format version of the parameter.
-   */
-  parameterFormatVersion: v.optional(v.number()),
 });
 export type StxSignMessageParams = v.InferOutput<typeof stxSignMessageParamsSchema>;
 

--- a/src/request/types/stxMethods/signMessage.ts
+++ b/src/request/types/stxMethods/signMessage.ts
@@ -12,7 +12,7 @@ export const stxSignMessageParamsSchema = v.object({
   /**
    * The public key to sign the message with.
    */
-  publicKey: v.string(),
+  publicKey: v.optional(v.string()),
 
   /**
    * The format version of the parameter.

--- a/src/request/types/stxMethods/signStructuredMessage.ts
+++ b/src/request/types/stxMethods/signStructuredMessage.ts
@@ -15,11 +15,6 @@ export const stxSignStructuredMessageParamsSchema = v.object({
   message: v.string(),
 
   /**
-   * The format version of the parameter.
-   */
-  parameterFormatVersion: v.optional(v.number()),
-
-  /**
    * The public key to sign the message with.
    */
   publicKey: v.optional(v.string()),


### PR DESCRIPTION
## Changes
- Update Axios Dependency
-  make publicKey optional in `stxSignMessageParamsSchema`