### PR TITLE
Update walletTypeSchema import

### DIFF
--- a/src/addresses/types.ts
+++ b/src/addresses/types.ts
@@ -1,6 +1,6 @@
 import * as v from 'valibot';
 import type { RequestOptions, RequestPayload } from '../types';
-import { walletTypeSchema } from '../request';
+import { walletTypeSchema } from '../request/types/common';
 
 export enum AddressPurpose {
   Ordinals = 'ordinals',


### PR DESCRIPTION
The import for `walletTypeSchema` has been updated to point to the file it is originally exported from, rather than the re-export from the index file. Using the re-exported source confuses the bundler, tsup, causing the variable to be assigned a value in the bundle in a location after it's first use, causing its value to be (unexpectedly) `undefined` where it is first used, causing errors.
